### PR TITLE
Clarify runtime scales differently and minor fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Following is a visualization of `tv1d::condat` with varying `lambda` applied to 
 
 "base pair" denotes the position at the transcript. "expression value" denotes the level of expression at a given "base pair" after denoising. "lambda" is the degree of denoising applied to the signals, and `0` is the raw signals.
 
-The plots were generated with [`ggpy'](https://github.com/yhat/ggpy).
+The plots were generated with [`ggpy`](https://github.com/yhat/ggpy).
 
 ![tv1d line plot](./examples/images/tv1d_line_plot.png)
 <br>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::ops;
 /// Davies P. and Kovac A. in 2001 in the paper ["Local extremes,
 /// runs, strings and
 /// multiresolution"](https://pure.tue.nl/ws/files/2200362/Metis214115.pdf). This
-/// algorithm scales linearly with respect to signal length.
+/// algorithm's run time scales linearly with respect to signal length.
 ///
 /// The algorithm was implemented by Condat L. in C, which was then
 /// implemented in Rust here. The algorithm can be understood as
@@ -233,8 +233,9 @@ pub fn tautstring<T>(input: &[T], lambda: T) -> Vec<T>
 /// described by Condat L. in 2013 in the paper ["A Direct Algorithm
 /// for 1D Total Variation
 /// Denoising"](https://hal.archives-ouvertes.fr/hal-00675043v2/document).
-/// While this algorithm scales at worst quadratically with respect to
-/// signal length, it appears faster in practical situations.
+/// While this algorithm's run time scales at worst quadratically with
+/// respect to signal length, it appears faster in practical
+/// situations.
 ///
 /// A `lambda` value may provide different degrees of denoising for
 /// different inputs, except for `lambda` that is `0`.


### PR DESCRIPTION
Clarify in doc string that the run time scales linearly/quadratically. Fix a minor thing in readme.